### PR TITLE
Break MSIM dependency on qci-telephony-framework

### DIFF
--- a/res/drawable/ic_lock.xml
+++ b/res/drawable/ic_lock.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="#009688"
+        android:pathData="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1 .9 2 2
+    2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9
+    2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z" />
+</vector>
+

--- a/res/drawable/ic_selected.xml
+++ b/res/drawable/ic_selected.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:pathData="M0 0h24v24h-24z" />
+    <path
+        android:fillColor="#009688"
+        android:pathData="M9 16.17l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41z" />
+</vector>

--- a/res/drawable/ic_sim.xml
+++ b/res/drawable/ic_sim.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="#009688"
+        android:pathData="M19.99 4c0-1.1-.89-2-1.99-2h-8L4 8v12c0 1.1 .9 2 2 2h12.01c1.1 0 1.99-.9
+    1.99-2l-.01-16zM9 19H7v-2h2v2zm8 0h-2v-2h2v2zm-8-4H7v-4h2v4zm4
+    4h-2v-4h2v4zm0-6h-2v-2h2v2zm4 2h-2v-4h2v4z" />
+</vector>

--- a/res/layout/pref_network_select_current.xml
+++ b/res/layout/pref_network_select_current.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ImageView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:src="@drawable/ic_selected"/>

--- a/res/layout/pref_network_select_lock.xml
+++ b/res/layout/pref_network_select_lock.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ImageView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:src="@drawable/ic_lock"/>

--- a/res/layout/pref_network_select_sim.xml
+++ b/res/layout/pref_network_select_sim.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ImageView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:src="@drawable/ic_sim"/>

--- a/res/menu/carrier_select_options.xml
+++ b/res/menu/carrier_select_options.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2015 The CyanogenMod Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+        parent="@android:style/Theme.Material.Settings">
+    <item
+        android:id="@+id/action_search_networks"
+        android:icon="@*android:drawable/ic_menu_refresh"
+        android:title="@string/search_networks"
+        android:showAsAction="ifRoom|withText" />
+</menu>

--- a/res/values-af/strings.xml
+++ b/res/values-af/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Jou diensverskaffer ondersteun nie die deaktivering van oproepaanstuur wanneer jou foon onbereikbaar is nie."</string>
     <string name="updating_title" msgid="6146755386174019046">"Belinstellings"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Oproepinstellings kan net deur die primêre gebruiker verander word."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Oproepinstellings (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Instellings (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Oproepinstellingsfout"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Lees tans instellings…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"Opdateer tans instellings…"</string>

--- a/res/values-am/strings.xml
+++ b/res/values-am/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"ስልክህ በማይደረስበት ጊዜ የድምጽ ተያያዥ ሞደምህ  የጥሪ-ማስተላለፍን አይደግፍም።"</string>
     <string name="updating_title" msgid="6146755386174019046">"የጥሪ ቅንብሮች"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"የጥሪ ቅንብሮች በተቀዳሚው ተጠቃሚ ብቻ ሊለወጡ ይችላሉ።"</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"የጥሪ ቅንብሮች (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"ቅንብሮች (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"የጥሪ ቅንብሮች ስህተት"</string>
     <string name="reading_settings" msgid="1920291699287055284">"ቅንብሮች በማንበብ ላይ..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"ቅንብሮችን በማዘመን ላይ…"</string>

--- a/res/values-ar/strings.xml
+++ b/res/values-ar/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"لا يتيح مشغل شبكة الجوال تعطيل اعادة توجيه المكالمة عند عدم التمكن من الوصول إلى هاتفك."</string>
     <string name="updating_title" msgid="6146755386174019046">"إعدادات الاتصال"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"لا يمكن تغيير إعدادات المكالمات إلا بواسطة المستخدم الأساسي."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"إعدادات المكالمات (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"الإعدادات (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"خطأ في إعدادات الاتصال"</string>
     <string name="reading_settings" msgid="1920291699287055284">"جارٍ قراءة الإعدادات..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"جارٍ تحديث الإعدادات..."</string>

--- a/res/values-az-rAZ/strings.xml
+++ b/res/values-az-rAZ/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Sizin mobil daşıyıcı telefon əlçatmaz olduğu zaman zəng yönləndirməni deaktiv etməyi dəstəkləmir."</string>
     <string name="updating_title" msgid="6146755386174019046">"Zəng parametrləri"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Zəng parametrləri yalnız əsas istifadəçi tərəfindən dəyişdirilə bilər."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Zəng parametrləri (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Ayarlar ( <xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g> )"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Zəng parametrləri xətası"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Oxuma parametrləri ..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"Ayarlar güncəlləşdirilir…"</string>

--- a/res/values-bg/strings.xml
+++ b/res/values-bg/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Операторът ви не поддържа деактивиране на пренасочването на обаждания, когато няма връзка с телефона."</string>
     <string name="updating_title" msgid="6146755386174019046">"Настройки за обаждане"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Само основният потребител може да променя настройките за обаждане."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Настройки (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Настройки (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Грешка в настройките за обаждане"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Извършва се четене на настройки…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"Настройките се актуализират…"</string>

--- a/res/values-bn-rBD/strings.xml
+++ b/res/values-bn-rBD/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"আপনার ক্যারিয়ার আপনার ফোনের সাথে যখন সংযোগ স্থাপন করা যাচ্ছে না সেই অবস্থায় কল ফরওয়ার্ডিংকে অক্ষম করা সমর্থন করে না৷"</string>
     <string name="updating_title" msgid="6146755386174019046">"কল সেটিংস"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"কেবলমাত্র প্রাথমিক ব্যবহারকারী কল সেটিংস পরিবর্তন করতে পারবেন৷"</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"কল সেটিংস (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"সেটিংস (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"কল সেটিংসে ত্রুটি"</string>
     <string name="reading_settings" msgid="1920291699287055284">"সেটিংস পড়ছে…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"সেটিংস আপডেট হচ্ছে..."</string>

--- a/res/values-ca/strings.xml
+++ b/res/values-ca/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"El teu operador de telefonia mòbil no permet desactivar la desviació de trucades quan el telèfon estigui il·localitzable."</string>
     <string name="updating_title" msgid="6146755386174019046">"Configuració de trucada"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Només l\'usuari principal pot canviar la configuració de trucades."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Configuració de trucades (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Configuració (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Error de configuració de trucada"</string>
     <string name="reading_settings" msgid="1920291699287055284">"S\'està llegint la configuració…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"S\'està actualitzant la configuració..."</string>

--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Váš operátor neumožňuje deaktivovat přesměrování hovorů, když je telefon nedostupný."</string>
     <string name="updating_title" msgid="6146755386174019046">"Nastavení hovorů"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Nastavení hovorů může změnit pouze primární uživatel."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Nastavení hovorů (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Nastavení (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Chyba nastavení hovorů"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Načítání nastavení..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"Probíhá aktualizace nastavení..."</string>

--- a/res/values-da/strings.xml
+++ b/res/values-da/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Dit mobilselskab understøtter ikke deaktivering af viderestilling af opkald, når telefonen ikke er tilgængelig."</string>
     <string name="updating_title" msgid="6146755386174019046">"Indstillinger for opkald"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Opkaldsindstillinger kan kun ændres af den primære bruger."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Opkaldsindstillinger (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Indstillinger (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Fejl i indstillinger for opkald"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Læser indstillinger ..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"Opdaterer indstillinger ..."</string>
@@ -196,7 +196,7 @@
     <item msgid="1524224863879435516">"Kun GSM"</item>
     <item msgid="3817924849415716259">"GSM/WCDMA foretrækkes"</item>
   </string-array>
-    <string name="enhanced_4g_lte_mode_title" msgid="522191650223239171">"Forbedret 4G LTE-tilstand"</string>
+    <string name="enhanced_4g_lte_mode_title" msgid="522191650223239171">"Udvidet 4G LTE-tilstand"</string>
     <string name="enhanced_4g_lte_mode_summary" msgid="2332175070522125850">"Anvend LTE-tjenester til at forbedre tale og anden kommunikation (anbefalet)"</string>
     <string name="data_enabled" msgid="5972538663568715366">"Data aktiveret"</string>
     <string name="data_enable_summary" msgid="2382798156640007971">"Tillad dataforbrug"</string>
@@ -353,7 +353,7 @@
     <string name="sum_fdn_change_pin" msgid="6666549734792827932">"Skift pinkode for at få adgang til begrænset opkald."</string>
     <string name="sum_fdn_manage_list" msgid="8431088265332628316">"Administrer liste over telefonnumre"</string>
     <string name="voice_privacy" msgid="3776841382844614716">"Privat talekommunikation"</string>
-    <string name="voice_privacy_summary" msgid="3159383389833516214">"Aktivér øget fortrolighedstilstand"</string>
+    <string name="voice_privacy_summary" msgid="3159383389833516214">"Aktivér udvidet fortrolighedstilstand"</string>
     <string name="tty_mode_option_title" msgid="9033098925144434669">"TTY-tilstand"</string>
     <string name="tty_mode_option_summary" msgid="1073835131534808732">"Angiv TTY-tilstand"</string>
     <string name="auto_retry_mode_title" msgid="4073265511427813322">"Prøv automatisk igen"</string>
@@ -545,7 +545,7 @@
     <string name="preference_category_ringtone" msgid="5197960752529332721">"Ringetone og vibration"</string>
     <string name="pstn_connection_service_label" msgid="1743245930577325900">"Indbyggede SIM-kort"</string>
     <string name="enable_video_calling_title" msgid="7237253660669000899">"Slå videoopkald til"</string>
-    <string name="enable_video_calling_dialog_msg" msgid="8948186136957417948">"Før du kan slå videoopkald til, skal du aktivere Forbedret 4G LTE-tilstand i netværksindstillinger."</string>
+    <string name="enable_video_calling_dialog_msg" msgid="8948186136957417948">"Før du kan slå videoopkald til, skal du aktivere Udvidet 4G LTE-tilstand i netværksindstillinger."</string>
     <string name="enable_video_calling_dialog_settings" msgid="576528473599603249">"Netværksindstillinger"</string>
     <string name="enable_video_calling_dialog_close" msgid="7411471282167927991">"Luk"</string>
     <string name="sim_label_emergency_calls" msgid="4847699229529306397">"Nødopkald"</string>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Ihr Mobilfunkanbieter unterstützt die Deaktivierung der Anrufweiterleitung bei Nichterreichbarkeit nicht."</string>
     <string name="updating_title" msgid="6146755386174019046">"Anrufeinstellungen"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Anrufeinstellungen können nur vom primären Nutzer geändert werden."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Anrufeinstellungen (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Einstellungen (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Fehler bei Anrufeinstellungen"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Einstellungen werden gelesen…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"Einstellungen werden aktualisiert…"</string>

--- a/res/values-el/strings.xml
+++ b/res/values-el/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Η εταιρεία κινητής τηλεφωνίας δεν υποστηρίζει την απενεργοποίηση της προώθησης κλήσεων όταν το τηλέφωνό σας δεν έχει σήμα."</string>
     <string name="updating_title" msgid="6146755386174019046">"Ρυθμίσεις κλήσης"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Οι ρυθμίσεις κλήσεων μπορούν να αλλάξουν μόνο από τον κύριο χρήστη."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Ρυθ/σεις (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Ρυθμίσεις (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Σφάλμα ρυθμίσεων κλήσης"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Ανάγνωση ρυθμίσεων…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"Ενημέρωση ρυθμίσεων..."</string>

--- a/res/values-en-rAU/strings.xml
+++ b/res/values-en-rAU/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Your operator doesn\'t support disabling call forwarding when your phone is unreachable."</string>
     <string name="updating_title" msgid="6146755386174019046">"Call settings"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Call settings can only be changed by the primary user."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Call settings (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Settings (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Call settings error"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Reading settings…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"Updating settings…"</string>

--- a/res/values-en-rGB/strings.xml
+++ b/res/values-en-rGB/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Your operator doesn\'t support disabling call forwarding when your phone is unreachable."</string>
     <string name="updating_title" msgid="6146755386174019046">"Call settings"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Call settings can only be changed by the primary user."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Call settings (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Settings (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Call settings error"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Reading settings…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"Updating settings…"</string>

--- a/res/values-en-rIN/strings.xml
+++ b/res/values-en-rIN/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Your operator doesn\'t support disabling call forwarding when your phone is unreachable."</string>
     <string name="updating_title" msgid="6146755386174019046">"Call settings"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Call settings can only be changed by the primary user."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Call settings (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Settings (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Call settings error"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Reading settings…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"Updating settings…"</string>

--- a/res/values-es-rUS/strings.xml
+++ b/res/values-es-rUS/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Tu proveedor no admite la inhabilitación del desvío de llamadas cuando no se puede acceder a tu teléfono."</string>
     <string name="updating_title" msgid="6146755386174019046">"Config. de llamada"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Solo el usuario principal puede cambiar la configuración de llamadas."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Configuración de llamadas (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Configuración (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Error en configuración de llamada"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Leyendo configuración..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"Actualizando configuración..."</string>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Tu operador no permite inhabilitar el desvío de llamadas si no se puede establecer la llamada."</string>
     <string name="updating_title" msgid="6146755386174019046">"Ajustes de llamadas"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"El usuario principal es el único que puede cambiar los ajustes de llamadas."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Ajustes de llamadas (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Ajustes (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Error de configuración de llamada"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Leyendo ajustes..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"Actualizando ajustes..."</string>

--- a/res/values-et-rEE/strings.xml
+++ b/res/values-et-rEE/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Teie operaator ei toeta kõneedastuse keelamist, kui teie telefon on levist väljas."</string>
     <string name="updating_title" msgid="6146755386174019046">"Kõneseaded"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Kõne seadeid saab muuta ainult peamine kasutaja."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Kõne seaded (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Seaded (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Kõneseadete viga"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Seadete lugemine ..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"Seadete värskendamine ..."</string>

--- a/res/values-eu-rES/strings.xml
+++ b/res/values-eu-rES/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Operadoreak ez du dei-desbideratzeak desgaitzea onartzen telefonoa eskuragarri ez dagoen bitartean."</string>
     <string name="updating_title" msgid="6146755386174019046">"Deien ezarpenak"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Erabiltzaile nagusiak soilik alda ditzake deien ezarpenak."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Deien ezarpenak (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Ezarpenak (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Deien ezarpenen errorea"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Ezarpenak irakurtzen…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"Ezarpenak eguneratzen…"</string>

--- a/res/values-fa/strings.xml
+++ b/res/values-fa/strings.xml
@@ -40,7 +40,7 @@
     <string name="pause_prompt_str" msgid="1789964702154314806">"تون‌های ارسالی\n"</string>
     <string name="send_button" msgid="4106860097497818751">"ارسال"</string>
     <string name="pause_prompt_yes" msgid="3564467212025151797">"بله"</string>
-    <string name="pause_prompt_no" msgid="6686238803236884877">"خیر"</string>
+    <string name="pause_prompt_no" msgid="6686238803236884877">"نه"</string>
     <string name="wild_prompt_str" msgid="5543521676355533577">"جایگزینی نویسه عمومی با"</string>
     <string name="no_vm_number" msgid="4164780423805688336">"عدم وجود شماره پست صوتی"</string>
     <string name="no_vm_number_msg" msgid="1300729501030053828">"شماره پست صوتی در سیم کارت ذخیره نشده است."</string>
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"شرکت مخابراتی شما از غیرفعال کردن هدایت تماس هنگامی که تلفن شما در دسترس نیست پشتیبانی نمی‌کند."</string>
     <string name="updating_title" msgid="6146755386174019046">"تنظیمات تماس"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"فقط کاربر اصلی می‌تواند تنظیمات تماس را تغییر دهد."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"تنظیمات تماس (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"تنظیمات (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"خطای تنظیمات تماس"</string>
     <string name="reading_settings" msgid="1920291699287055284">"در حال خواندن تنظیمات..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"در حال به‌روزرسانی تنظیمات..."</string>
@@ -520,7 +520,7 @@
     <string name="alert_dialog_in_ecm_call" msgid="1886723687211887104">"در حین یک تماس اضطراری، عملکرد انتخابی در دسترس نیست."</string>
     <string name="progress_dialog_exiting_ecm" msgid="4835734101617817074">"خروج از حالت پاسخ تماس اضطراری"</string>
     <string name="alert_dialog_yes" msgid="6674268047820703974">"بله"</string>
-    <string name="alert_dialog_no" msgid="1476091437797628703">"خیر"</string>
+    <string name="alert_dialog_no" msgid="1476091437797628703">"نه"</string>
     <string name="alert_dialog_dismiss" msgid="2491494287075907171">"رد کردن"</string>
     <string name="voicemail_provider" msgid="5135942703327136909">"سرویس"</string>
     <string name="voicemail_settings" msgid="72448049107749316">"تنظیم"</string>

--- a/res/values-fi/strings.xml
+++ b/res/values-fi/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Operaattorisi ei tue soitonsiirtojen poistamista käytöstä puhelimesi ollessa saavuttamattomissa."</string>
     <string name="updating_title" msgid="6146755386174019046">"Puheluasetukset"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Vain ensisijainen käyttäjä voi muuttaa puheluasetuksia."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Puheluasetukset (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Asetukset (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Virhe puheluasetuksissa"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Luetaan asetuksia…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"Päivitetään asetuksia..."</string>

--- a/res/values-fr-rCA/strings.xml
+++ b/res/values-fr-rCA/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Votre opérateur ne permet pas la désactivation du transfert d\'appel lorsque votre téléphone n\'est pas joignable."</string>
     <string name="updating_title" msgid="6146755386174019046">"Paramètres d\'appel"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Seul l\'utilisateur principal peut modifier les paramètres d\'appel."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Paramètres d\'appel (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Paramètres (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Erreur des paramètres d\'appel"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Lecture des paramètres..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"Mise à jour des paramètres en cours…"</string>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Votre opérateur ne permet pas la désactivation du transfert d\'appel lorsque votre téléphone n\'est pas joignable."</string>
     <string name="updating_title" msgid="6146755386174019046">"Paramètres d\'appel"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Seul l\'utilisateur principal peut modifier les paramètres d\'appel."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Param. d\'appel (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Paramètres (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Erreur des paramètres d\'appel"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Lecture des paramètres..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"Mise à jour des paramètres..."</string>

--- a/res/values-gl-rES/strings.xml
+++ b/res/values-gl-rES/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"O teu operador non admite a desactivación do desvío de chamadas cando non se pode acceder ao teléfono."</string>
     <string name="updating_title" msgid="6146755386174019046">"Configuración de chamada"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Só o usuario principal pode cambiar a configuración de chamada."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Configuración de chamada (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Configuración (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Erro de configuración das chamadas"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Lendo a configuración..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"Actualizando a configuración..."</string>

--- a/res/values-gu-rIN/strings.xml
+++ b/res/values-gu-rIN/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"જ્યારે તમારો ફોન પહોંચયોગ્ય ન હોય ત્યારે તમારા કેરિઅર કૉલ ફોરવર્ડિંગને અક્ષમ કરવાને સમર્થન આપતા નથી."</string>
     <string name="updating_title" msgid="6146755386174019046">"કૉલ સેટિંગ્સ"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"કૉલ સેટિંગ્સને ફક્ત પ્રાથમિક વપરાશકર્તા દ્વારા જ બદલી શકાય છે."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"કૉલ સેટિંગ્સ (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"સેટિંગ્સ (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"કૉલ સેટિંગ્સની ભૂલ"</string>
     <string name="reading_settings" msgid="1920291699287055284">"સેટિંગ્સ વાંચી રહ્યાં છે…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"સેટિંગ્સ અપડેટ કરી રહ્યાં છે..."</string>

--- a/res/values-hi/strings.xml
+++ b/res/values-hi/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"जब आपका फ़ोन पहुंच योग्य न हो, तो आपका कैरियर कॉल अग्रेषण अक्षम करने का समर्थन नहीं करता."</string>
     <string name="updating_title" msgid="6146755386174019046">"कॉल सेटिंग"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"कॉल सेटिंग केवल प्राथमिक उपयोगकर्ता द्वारा ही बदली जा सकती हैं."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"कॉल सेटिंग (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"सेटिंग (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"कॉल सेटिंग त्रुटि"</string>
     <string name="reading_settings" msgid="1920291699287055284">"सेटिंग पढ़ रहा है..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"सेटिंग के लिए नई जानकारी मिल रही है..."</string>

--- a/res/values-hr/strings.xml
+++ b/res/values-hr/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Vaš mobilni operater ne podržava onemogućavanje preusmjeravanja poziva ako je vaš telefon nedostupan."</string>
     <string name="updating_title" msgid="6146755386174019046">"Postavke poziva"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Postavke može mijenjati samo primarni korisnik."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Post. poziva (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Postavke (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Pogreška postavki poziva"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Čitanje postavki..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"Ažuriranje postavki..."</string>

--- a/res/values-hu/strings.xml
+++ b/res/values-hu/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Szolgáltatója nem támogatja a hívásátirányítás letiltását, ha a telefon nem érhető el."</string>
     <string name="updating_title" msgid="6146755386174019046">"Hívásbeállítások"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"A hívásbeállításokat csak az elsődleges felhasználó módosíthatja."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Hívásbeállítások (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Beállítások (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Hiba a hívásbeállításokban"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Beállítások olvasása..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"Beállítások frissítése..."</string>

--- a/res/values-hy-rAM/strings.xml
+++ b/res/values-hy-rAM/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Ձեր սպասարկողը չի աջակցում զանգի վերահասցեավորման կասեցում, երբ ձեր հեռախոսն անհասանելի է:"</string>
     <string name="updating_title" msgid="6146755386174019046">"Զանգի կարգավորումներ"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Զանգի կարգավորումները կարող է փոխել միայն հիմնական օգտագործողը:"</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Զանգի կարգավորումներ (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Կարգավորումներ (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Զանգի կարգավորումների սխալ"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Ընթերցման կարգավորումներ..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"Թարմացվում են կարգավորումները..."</string>

--- a/res/values-in/strings.xml
+++ b/res/values-in/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Operator Anda tidak mendukung penonaktifan penerusan panggilan ketika ponsel tidak dapat dijangkau."</string>
     <string name="updating_title" msgid="6146755386174019046">"Setelan panggilan"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Setelan panggilan hanya dapat diubah oleh pengguna utama."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Setelan panggilan (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Setelan (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Kesalahan setelan panggilan"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Membaca setelan…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"Memperbarui setelan…"</string>

--- a/res/values-is-rIS/strings.xml
+++ b/res/values-is-rIS/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Símafyrirtækið leyfir ekki að slökkt sé á símtalsflutningi þegar ekki næst í símann."</string>
     <string name="updating_title" msgid="6146755386174019046">"Símtalsstillingar"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Aðeins aðalnotandinn má breyta símtalsstillingum."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Símtalsstillingar (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Stillingar (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Villa í símtalsstillingum"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Les stillingar…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"Uppfærir stillingar…"</string>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Il tuo operatore non supporta la disattivazione dell\'inoltro chiamate quando il telefono non è raggiungibile."</string>
     <string name="updating_title" msgid="6146755386174019046">"Impostazioni chiamate"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Le impostazioni delle chiamate possono essere modificate solo dall\'utente principale."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Impostazioni chiamate (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Impostazioni (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Errore durante aggiornam. impostaz. chiamate"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Lettura impostazioni..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"Aggiornamento impostazioni..."</string>

--- a/res/values-iw/strings.xml
+++ b/res/values-iw/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"הספק שלך לא תומך בהשבתה של העברת שיחות כאשר הטלפון כבוי."</string>
     <string name="updating_title" msgid="6146755386174019046">"הגדרות שיחה"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"רק המשתמש הראשי יכול לשנות הגדרות שיחה."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"הגדרות שיחה (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"הגדרות (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"שגיאה בהגדרות שיחה"</string>
     <string name="reading_settings" msgid="1920291699287055284">"קורא הגדרות…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"מעדכן הגדרות..."</string>

--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"ご利用の携帯通信会社は着信不能時の転送の無効化をサポートしていません。"</string>
     <string name="updating_title" msgid="6146755386174019046">"通話設定"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"通話設定はメインユーザーのみが変更できます。"</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"通話設定（<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>）"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"設定（<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>）"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"通話設定エラー"</string>
     <string name="reading_settings" msgid="1920291699287055284">"設定を読み取り中..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"設定を更新中..."</string>

--- a/res/values-ka-rGE/strings.xml
+++ b/res/values-ka-rGE/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"თქვენს ოპერატორს ტელეფონის მიუწვდომელობის დროს ზარის გადამისამართების გაუქმების მხარდაჭერა არ გააჩნია."</string>
     <string name="updating_title" msgid="6146755386174019046">"ზარის პარამეტრები"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"ზარის პარამეტრების ცვლილება შესაძლებელია მხოლოდ პირველადი მომხმარებლის მიერ."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"ზარის პარამეტრები (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"პარამეტრები (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"ზარის პარამეტრების შეცდომა"</string>
     <string name="reading_settings" msgid="1920291699287055284">"პარამეტრების წაკითხვა…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"პარამეტრების განახლება…"</string>

--- a/res/values-kk-rKZ/strings.xml
+++ b/res/values-kk-rKZ/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Телефоныңыз қол жетімсіз болғанда жабдықтаушы қоңырауды басқа нөмірге бағыттауды өшіруді қолдамайды."</string>
     <string name="updating_title" msgid="6146755386174019046">"Қоңырау параметрлері"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Қоңырау параметрлерін тек негізгі пайдаланушы өзгерте алады."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Қоңырау параметрлері (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Параметрлер (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Қоңырау параметрлерінің қателігі"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Параметрлерді оқуда…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"Параметрлерді жаңартуда…"</string>

--- a/res/values-km-rKH/strings.xml
+++ b/res/values-km-rKH/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"ក្រុមហ៊ុន​បញ្ជូន​របស់​អ្នក​​មិន​គាំទ្រ​ការ​បិទ​ការ​ហៅ​​បញ្ជូន​បន្ត នៅ​ពេល​ទូរស័ព្ទ​របស់​អ្នក​មិន​អាច​ហៅ​ចូល។"</string>
     <string name="updating_title" msgid="6146755386174019046">"កំណត់​ការ​ហៅ"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"ការកំណត់ការហៅអាចផ្លាស់ប្តូរបានដោយអ្នកប្រើបឋមតែប៉ុណ្ណោះ។"</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"ការកំណត់ការហៅ (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"ការកំណត់ (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"កំហុស​ការ​កំណត់​ការ​ហៅ"</string>
     <string name="reading_settings" msgid="1920291699287055284">"កំពុង​អាន​ការ​កំណត់…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"កំណត់​ការ​ធ្វើ​បច្ចុប្បន្ន​ភាព…"</string>

--- a/res/values-kn-rIN/strings.xml
+++ b/res/values-kn-rIN/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"ನಿಮ್ಮ ಫೋನ್‌ ಅನ್ನು ತಲುಪಲಾಗದಿದ್ದಾಗ ನಿಮ್ಮ ವಾಹಕ ಕರೆ ಫಾರ್ವರ್ಡ್‌ ಮಾಡುವಿಕೆ ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಲು ಬೆಂಬಲಿಸುವುದಿಲ್ಲ."</string>
     <string name="updating_title" msgid="6146755386174019046">"ಕರೆ ಸೆಟ್ಟಿಂಗ್‌ಗಳು"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"ಕರೆ ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ಕೇವಲ ಪ್ರಾಥಮಿಕ ಬಳಕೆದಾರರು ಮಾತ್ರ ಬದಲಾಯಿಸಬಹುದು."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"ಕರೆ ಸೆಟ್ಟಿಂಗ್‌ಗಳು (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"ಸೆಟ್ಟಿಂಗ್‌ಗಳು (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"ಕರೆ ಸೆಟ್ಟಿಂಗ್‌ಗಳ ದೋಷ"</string>
     <string name="reading_settings" msgid="1920291699287055284">"ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ಓದಲಾಗುತ್ತಿದೆ…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ನವೀಕರಿಸಲಾಗುತ್ತಿದೆ…"</string>

--- a/res/values-ko/strings.xml
+++ b/res/values-ko/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"이동통신사에서 전화를 받을 수 없을 때 착신전환 사용 중지를 지원하지 않습니다."</string>
     <string name="updating_title" msgid="6146755386174019046">"통화 설정"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"기본 사용자만 통화 설정을 변경할 수 있습니다."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"통화 설정(<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"설정(<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"통화 설정 오류"</string>
     <string name="reading_settings" msgid="1920291699287055284">"설정을 읽는 중..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"설정 업데이트 중..."</string>

--- a/res/values-ky-rKG/strings.xml
+++ b/res/values-ky-rKG/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Сиздин операторуңуз, телефон жеткиликсиз болгондо чалууну багыттоону токтотууну колдобойт."</string>
     <string name="updating_title" msgid="6146755386174019046">"Чалуу жөндөөлөрү"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Чалуу жөндөөлөрүн алгачкы колдонуучу гана өзгөртө алат."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Чалуу жөндөөлөрү (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Жөндөөлөр (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Чалуу жөндөөлөрүндөгү ката"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Жөндөөлөр окулууда…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"Жөндөөлөр жаңыртылууда…"</string>

--- a/res/values-lo-rLA/strings.xml
+++ b/res/values-lo-rLA/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"ຜູ່ໃຫ້ບໍລິການຂອງທ່ານ ບໍ່ຮອງຮັບການປິດການໂອນສາຍ ເມື່ອໂທລະສັບຂອງທ່ານບໍ່ມີສັນຍານ."</string>
     <string name="updating_title" msgid="6146755386174019046">"ການຕັ້ງຄ່າການໂທ"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"ມີ​ແຕ່​ຜູ້​ໃຊ້​ຕົ້ນ​ຕໍ​ເທົ່າ​ນັ້ນ​ທີ່​ສາ​ມາດ​ປ່ຽນການ​ຕັ້ງ​ຄ່າ​ການ​ໂທ​ໄດ້."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"ການ​ຕັ້ງ​ຄ່າ​ການ​ໂທ (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"ການ​ຕັ້ງ​ຄ່າ (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"ການຕັ້ງຄ່າການໂທຜິດພາດ"</string>
     <string name="reading_settings" msgid="1920291699287055284">"ກຳລັງອ່ານການຕັ້ງຄ່າ..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"ກຳລັງອັບເດດການຕັ້ງຄ່າ..."</string>

--- a/res/values-lt/strings.xml
+++ b/res/values-lt/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Operatorius nepalaiko skambučių peradresavimo išjungimo, kai telefonas nepasiekiamas."</string>
     <string name="updating_title" msgid="6146755386174019046">"Skambinimo nustatymai"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Skambučių nustatymus gali keisti tik pagrindinis naudotojas."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Skambučių nustatymai (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Nustatymai (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Skambinimo nustatymų klaida"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Skaitomi nustatymai..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"Atnaujinami nustatymai..."</string>

--- a/res/values-lv/strings.xml
+++ b/res/values-lv/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Jūsu mobilo sakaru operators neatbalsta zvanu pāradresācijas atspējošanu, ja tālrunis nav sasniedzams."</string>
     <string name="updating_title" msgid="6146755386174019046">"Zvanu iestatījumi"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Tikai galvenais lietotājs var mainīt zvanu iestatījumus."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Zvanu iestatījumi (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Iestatījumi (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Zvanu iestatījumu kļūda"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Notiek iestatījumu lasīšana..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"Notiek iestatījumu atjaunināšana..."</string>

--- a/res/values-mk-rMK/strings.xml
+++ b/res/values-mk-rMK/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Вашиот оператор не поддржува оневозможување проследување повик кога вашиот телефон е недостапен."</string>
     <string name="updating_title" msgid="6146755386174019046">"Подесувања на повик"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Поставките за повик може да ги промени само главниот корисник."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Поставки за повик (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Поставки (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Грешка со подесување повици"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Подесувања за читање..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"Ажурирање подесувања..."</string>

--- a/res/values-ml-rIN/strings.xml
+++ b/res/values-ml-rIN/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"നിങ്ങളുടെ ഫോൺ പരിധിയ്ക്ക് പുറത്തായിരിക്കുമ്പോൾ കോൾ കൈമാറൽ പ്രവർത്തനരഹിതമാക്കുന്നതിനെ നിങ്ങളുടെ ഓപ്പറേറ്റർ പിന്തുണയ്‌ക്കുന്നില്ല."</string>
     <string name="updating_title" msgid="6146755386174019046">"കോൾ ക്രമീകരണങ്ങൾ"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"കോൾ ക്രമീകരണങ്ങൾ, പ്രാഥമിക ഉപയോക്താവിന് മാത്രമെ മാറ്റാനാവൂ."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"ക്രമീകരണം (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"ക്രമീകരണം (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"കോൾ ക്രമീകരണ പിശക്"</string>
     <string name="reading_settings" msgid="1920291699287055284">"ക്രമീകരണങ്ങൾ റീഡുചെയ്യുന്നു.…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"ക്രമീകരണങ്ങൾ അപ്‌ഡേറ്റുചെയ്യുന്നു…"</string>

--- a/res/values-mn-rMN/strings.xml
+++ b/res/values-mn-rMN/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Таны үүрэн холбоо үзүүлэгчээс утас завгүй байхад дуудлагыг дамжуулахыг зогсоох үйлчилгээг дэмждэггүй."</string>
     <string name="updating_title" msgid="6146755386174019046">"Дуудлагын тохиргоо"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Дуудлагын тохиргоог зөвхөн үндсэн хэрэглэгч өөрчлөх боломжтой."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Дуудлагын тохиргоо (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Тохиргоо (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Дуудлагын тохиргооны алдаа"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Тохиргоог уншиж байна…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"Тохиргоог шинэчилж байна…"</string>

--- a/res/values-mr-rIN/strings.xml
+++ b/res/values-mr-rIN/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"आपला फोन पोहचण्‍यायोग्‍य नसताना आपला वाहक कॉल अग्रेषण करणे अक्षम करण्‍यास समर्थन करीत नाही."</string>
     <string name="updating_title" msgid="6146755386174019046">"कॉल सेटिंग्ज"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"कॉल सेटिंग्ज केवळ प्राथमिक वापरकर्त्याद्वारे बदलल्‍या जाउ शकतात."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"(<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>) कॉल सेटिंग्ज"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"सेटिंग्ज (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"कॉल सेटिंग्ज त्रुटी"</string>
     <string name="reading_settings" msgid="1920291699287055284">"सेटिंग्‍ज वाचत आहे…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"सेटिंग्ज अद्यतनित करीत आहे..."</string>

--- a/res/values-ms-rMY/strings.xml
+++ b/res/values-ms-rMY/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Pembawa anda tidak menyokong pelumpuhan pemajuan panggilan semasa telefon anda tidak boleh dihubungi."</string>
     <string name="updating_title" msgid="6146755386174019046">"Tetapan panggilan"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Tetapan panggilan hanya boleh diubah oleh pengguna utama."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Tetapan panggilan (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Tetapan (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Ralat tetapan panggilan"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Membaca tetapan..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"Mengemas kini tetapan..."</string>

--- a/res/values-my-rMM/strings.xml
+++ b/res/values-my-rMM/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"သင့် ဖုန်း ဆက်သွယ်မှု လုပ်လို့မရစဉ် call forwarding ပြုလုပ်မှု ပယ်ဖျက်ရန် သင့် အော်ပရေတာမှ ခွင့်မပြုပါ"</string>
     <string name="updating_title" msgid="6146755386174019046">"ခေါ်ဆိုခြင်း အဆင်အပြင်များ"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"အဓိက အသုံးပြုသူသာလျှင် ခေါ်ဆိုမှု ချိန်ညှိချက်များကို ပြောင်းလဲနိုင်ပါသည်။"</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"ခေါ်ဆိုမှု ချိန်ညှိချက်များ (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"ဆက်တင်များ ( <xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g> )"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"ခေါ်ဆိုမှု အပြင်အဆင်အမှား"</string>
     <string name="reading_settings" msgid="1920291699287055284">"အပြင်အဆင်များကို ဖတ်နေပါသည်…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"ဆက်တင်များအား ပြင်နေသည်…"</string>

--- a/res/values-nb/strings.xml
+++ b/res/values-nb/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Operatøren støtter ikke deaktivering av viderekobling når telefonen er utenfor dekning."</string>
     <string name="updating_title" msgid="6146755386174019046">"Samtaleinnstillinger"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Anropsinnstillinger kan bare endres av hovedbrukeren."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Samtaleinnstillinger (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Innstillinger (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Feil ved samtaleinnstillinger"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Leser innstillingene …"</string>
     <string name="updating_settings" msgid="8171225533884883252">"Oppdaterer innstillinger…"</string>

--- a/res/values-ne-rNP/strings.xml
+++ b/res/values-ne-rNP/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"तपाईंको फोन पहुँचयोग्य नहुँदा तपाईंको केरियरले कल-फर्वार्डिङ असक्षम बनाउँदा समर्थन गर्दैन।"</string>
     <string name="updating_title" msgid="6146755386174019046">"कल सेटिङहरू"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"कल सेटिङहरू केवल प्राथमिक प्रयोगकर्ताद्वारा मात्र परिवर्तन गर्न सकिन्छ।"</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"कल सेटिङ ( <xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g> )"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"सेटिङहरू (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"कल सेटिङ त्रुटि"</string>
     <string name="reading_settings" msgid="1920291699287055284">"सेटिङहरू पढ्दै..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"सेटिङहरू अद्यावधिक गर्दै..."</string>
@@ -486,7 +486,7 @@
     <string name="ota_hfa_activation_title" msgid="2234246934160473981">"सक्रिय गर्दै…"</string>
     <string name="ota_hfa_activation_dialog_message" msgid="8092479227918463415">"फोनले तपाईँको मोबाइल डेटा सेवा सक्रिय पार्दै छ। \n\nयसले ५ मिनेटसम्म समय लिन सक्छ।"</string>
     <string name="ota_skip_activation_dialog_title" msgid="2943366608272261306">"सक्रिया गर्ने काम छोड्ने हो?"</string>
-    <string name="ota_skip_activation_dialog_message" msgid="2440770373498870550">"यदि तपाईं सक्रियता छोड्नुहुन्छ भने तपाईं कल वा मोबाइल डेटा नेटवर्क (तपाईं वाइफाइ नेटवर्क जडान गर्न सक्नु हुन्छ) बाट जडान गर्न सक्नु हुन्छ। तपाईंले आफ्नो फोनलाई सक्रिय गर्ने बेलासम्म तपाईं यसलाई हरेक पटक खोल्ने गर्नुहोस्।"</string>
+    <string name="ota_skip_activation_dialog_message" msgid="2440770373498870550">"यदि तपाईँ सक्रियता छोड्नुहुन्छ भने तपाईँ कल वा मोबाइल डेटा नेटवर्क (तपाईँ वाइफाइ नेटवर्क जडान गर्न सक्नु हुन्छ) बाट जडान गर्न सक्नु हुन्छ। तपाईँले आफ्नो फोनलाई सक्रिय गर्ने बेलासम्म तपाईँ यसलाई हरेक पटक खोल्ने गर्नुहोस्।"</string>
     <string name="ota_skip_activation_dialog_skip_label" msgid="3458532775091563208">"छोड्नुहोस्"</string>
     <string name="ota_activate" msgid="1368528132525626264">"सक्रिय बनाउनुहोस्"</string>
     <string name="ota_title_activate_success" msgid="6570240212263372046">"फोन सक्रिय भएको छ।"</string>
@@ -510,12 +510,12 @@
       <item quantity="one"> <xliff:g id="COUNT_0">%s</xliff:g> मिनेटको लागि कुनै डेटा जडान छैन</item>
     </plurals>
     <plurals name="alert_dialog_exit_ecm" formatted="false" msgid="7179911675595441201">
-      <item quantity="other"> फोन आपतकालीन कलब्याक मोडमा <xliff:g id="COUNT_1">%s</xliff:g> मिनेटको लागि हुनेछ। यस मोडको अवस्थामा एक डेटा जडान प्रयोग गरेर कुनै पनि अनुप्रयोगहरू प्रयोग गर्न सकिँदैन। के तपाईं अहिले निस्कन चाहनुहुन्छ?</item>
-      <item quantity="one"> फोन आपतकालीन कलब्याक मोडमा <xliff:g id="COUNT_0">%s</xliff:g> मिनेटको लागि हुनेछ। यस मोडको समयमा एक डेटा जडान प्रयोग गरेर कुनै पनि अनुप्रयोगहरू प्रयोग गर्न सकिँदैन। के तपाईं अहिले निस्कन चाहनुहुन्छ?</item>
+      <item quantity="other"> फोन आपतकालीन कलब्याक मोडमा <xliff:g id="COUNT_1">%s</xliff:g> मिनेटको लागि हुनेछ। यस मोडको अवस्थामा एक डेटा जडान प्रयोग गरेर कुनै पनि अनुप्रयोगहरू प्रयोग गर्न सकिँदैन। के तपाईँ अहिले निस्कन चाहनुहुन्छ?</item>
+      <item quantity="one"> फोन आपतकालीन कलब्याक मोडमा <xliff:g id="COUNT_0">%s</xliff:g> मिनेटको लागि हुनेछ। यस मोडको समयमा एक डेटा जडान प्रयोग गरेर कुनै पनि अनुप्रयोगहरू प्रयोग गर्न सकिँदैन। के तपाईँ अहिले निस्कन चाहनुहुन्छ?</item>
     </plurals>
     <plurals name="alert_dialog_not_avaialble_in_ecm" formatted="false" msgid="8042973425225093895">
-      <item quantity="other"> आपतकालीन कलब्याक मोडको समयमा चयनित कार्य उपलब्ध छैन। फोन यस मोडमा <xliff:g id="COUNT_1">%s</xliff:g> मिनेटको लागि हुनेछ। के तपाईं अहिले निस्कन चाहनुहुन्छ?</item>
-      <item quantity="one"> आपतकालीन कलब्याक मोडको समयमा चयनित कार्य उपलब्ध छैन। फोन यस मोडमा <xliff:g id="COUNT_0">%s</xliff:g> मिनेटको लागि हुनेछ। के तपाईं अहिले निस्कन चाहनुहुन्छ?</item>
+      <item quantity="other"> आपतकालीन कलब्याक मोडको समयमा चयनित कार्य उपलब्ध छैन। फोन यस मोडमा <xliff:g id="COUNT_1">%s</xliff:g> मिनेटको लागि हुनेछ। के तपाईँ अहिले निस्कन चाहनुहुन्छ?</item>
+      <item quantity="one"> आपतकालीन कलब्याक मोडको समयमा चयनित कार्य उपलब्ध छैन। फोन यस मोडमा <xliff:g id="COUNT_0">%s</xliff:g> मिनेटको लागि हुनेछ। के तपाईँ अहिले निस्कन चाहनुहुन्छ?</item>
     </plurals>
     <string name="alert_dialog_in_ecm_call" msgid="1886723687211887104">"आपतकालीन कल हुँदा चयन भएको कार्य उपलब्ध हुँदैन।"</string>
     <string name="progress_dialog_exiting_ecm" msgid="4835734101617817074">"आपतकालीन कलब्याक मोडबाट निस्कदै"</string>

--- a/res/values-nl/strings.xml
+++ b/res/values-nl/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Je provider biedt geen ondersteuning voor het uitschakelen van oproepdoorschakelingen wanneer je telefoon niet bereikbaar is."</string>
     <string name="updating_title" msgid="6146755386174019046">"Oproepinstellingen"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Oproepinstellingen kunnen alleen worden gewijzigd door de primaire gebruiker."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Oproepinstellingen (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Instellingen (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Fout met oproepinstellingen"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Instellingen lezen..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"Instellingen bijwerken..."</string>

--- a/res/values-pa-rIN/strings.xml
+++ b/res/values-pa-rIN/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"ਜਦੋਂ ਤੁਹਾਡਾ ਫੋਨ ਨਾਪਹੁੰਚਯੋਗ ਹੁੰਦਾ ਹੈ ਤਾਂ ਤੁਹਾਡਾ ਕੈਰੀਅਰ ਕਾਲ ਫੌਰਵਾਰਡਿੰਗ ਨੂੰ ਅਸਮਰੱਥ ਬਣਾਉਣ ਦਾ ਸਮਰਥਨ ਨਹੀਂ ਕਰਦਾ।"</string>
     <string name="updating_title" msgid="6146755386174019046">"ਕਾਲ ਸੈਟਿੰਗਾਂ"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"ਕਾਲ ਸੈਟਿੰਗਾਂ ਕੇਵਲ ਮੁੱਖ ਉਪਭੋਗਤਾ ਵੱਲੋਂ ਬਦਲੀਆਂ ਜਾ ਸਕਦੀਆਂ ਹਨ।"</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"ਕਾਲ ਸੈਟਿੰਗਾਂ (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"ਸੈਟਿੰਗਾਂ (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"ਕਾਲ ਸੈਟਿੰਗਾਂ ਅਸ਼ੁੱਧੀ"</string>
     <string name="reading_settings" msgid="1920291699287055284">"ਸੈਟਿੰਗਾਂ ਪੜ੍ਹ ਰਿਹਾ ਹੈ…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"ਸੈਟਿੰਗਾਂ ਅਪਡੇਟ ਕਰ ਰਿਹਾ ਹੈ…"</string>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Twój operator nie umożliwia wyłączenia przekazywania połączeń, gdy numer jest nieosiągalny."</string>
     <string name="updating_title" msgid="6146755386174019046">"Ustawienia połączeń"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Ustawienia połączeń może zmienić tylko użytkownik główny."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Ustawienia połączeń (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Ustawienia (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Błąd w ustawieniach połączenia"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Czytanie ustawień..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"Aktualizowanie ustawień..."</string>

--- a/res/values-pt-rPT/strings.xml
+++ b/res/values-pt-rPT/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"O seu operador não suporta a desativação do reencaminhamento de chamadas quando o telemóvel não está acessível."</string>
     <string name="updating_title" msgid="6146755386174019046">"Definições de chamadas"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"As definições de chamadas só podem ser alteradas pelo utilizador principal."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Definições de chamadas (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Definições (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Erro nas definições de chamada"</string>
     <string name="reading_settings" msgid="1920291699287055284">"A ler as definições..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"A atualizar as definições..."</string>

--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Sua operadora não suporta a desativação do encaminhamento de chamada quando seu telefone não está acessível."</string>
     <string name="updating_title" msgid="6146755386174019046">"Configurações de chamadas"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"As configurações de chamada só podem ser alteradas pelo usuário principal."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Config. de chamada (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Configurações (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Erro de configuração da chamada"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Lendo as configurações…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"Atualizando configurações…"</string>
@@ -352,7 +352,7 @@
     <string name="tty_mode_option_summary" msgid="1073835131534808732">"Definir modo TTD"</string>
     <string name="auto_retry_mode_title" msgid="4073265511427813322">"Repetir automaticamente"</string>
     <string name="auto_retry_mode_summary" msgid="4973886004067532288">"Ativar modo Repetir automaticamente"</string>
-    <string name="tty_mode_not_allowed_video_call" msgid="3795846787901909176">"Não é permitida a alteração do modo TTD durante uma vídeo chamada"</string>
+    <string name="tty_mode_not_allowed_video_call" msgid="3795846787901909176">"Não é permitida a alteração do modo TTD durante uma videochamada"</string>
     <string name="menu_add" msgid="1882023737425114762">"Adicionar contato"</string>
     <string name="menu_edit" msgid="7143003705504672374">"Editar contato"</string>
     <string name="menu_delete" msgid="3977150783449642851">"Excluir contato"</string>
@@ -460,7 +460,7 @@
     <string name="onscreenManageCallsText" msgid="5473231160123254154">"Gerenciar chamadas"</string>
     <string name="onscreenManageConferenceText" msgid="6485935856534311346">"Gerenciar conferência"</string>
     <string name="onscreenAudioText" msgid="1710087112800041743">"Áudio"</string>
-    <string name="onscreenVideoCallText" msgid="4800924186056115442">"Vídeo ch."</string>
+    <string name="onscreenVideoCallText" msgid="4800924186056115442">"Videocham."</string>
     <string name="importSimEntry" msgid="6614358325359736031">"Importar"</string>
     <string name="importAllSimEntries" msgid="1503181169636198673">"Importar tudo"</string>
     <string name="importingSimContacts" msgid="7374056215462575769">"Importando contatos do SIM"</string>
@@ -539,7 +539,7 @@
     <string name="preference_category_ringtone" msgid="5197960752529332721">"Toque e vibração"</string>
     <string name="pstn_connection_service_label" msgid="1743245930577325900">"Cartões SIM integrados"</string>
     <string name="enable_video_calling_title" msgid="7237253660669000899">"Ativar chamadas de vídeo"</string>
-    <string name="enable_video_calling_dialog_msg" msgid="8948186136957417948">"Para ativar a chamada de vídeo, ative o modo 4G LTE avançado nas configurações de rede."</string>
+    <string name="enable_video_calling_dialog_msg" msgid="8948186136957417948">"Para ativar a videochamada, ative o modo 4G LTE avançado nas configurações de rede."</string>
     <string name="enable_video_calling_dialog_settings" msgid="576528473599603249">"Configurações de rede"</string>
     <string name="enable_video_calling_dialog_close" msgid="7411471282167927991">"Fechar"</string>
     <string name="sim_label_emergency_calls" msgid="4847699229529306397">"Chamadas de emergência"</string>

--- a/res/values-ro/strings.xml
+++ b/res/values-ro/strings.xml
@@ -24,7 +24,7 @@
     <string name="unknown" msgid="6878797917991465859">"Necunoscut"</string>
     <string name="private_num" msgid="6713286113000232309">"Număr privat"</string>
     <string name="payphone" msgid="4793877574636445118">"Telefon public"</string>
-    <string name="onHold" msgid="9035493194749959955">"În aşteptare"</string>
+    <string name="onHold" msgid="9035493194749959955">"În așteptare"</string>
     <string name="mmiStarted" msgid="6347869857061147003">"Cod MMI pornit"</string>
     <string name="ussdRunning" msgid="485588686340541690">"Se rulează codul USSD..."</string>
     <string name="mmiCancelled" msgid="2771923949751842276">"Cod MMI anulat"</string>
@@ -50,7 +50,7 @@
     <string name="sim_ndp_unlock_text" msgid="683628237760543009">"Deblocaţi"</string>
     <string name="sim_ndp_dismiss_text" msgid="1604823375752456947">"Renunţaţi"</string>
     <string name="requesting_unlock" msgid="6412629401033249351">"Se solicită deblocarea reţelei..."</string>
-    <string name="unlock_failed" msgid="6490531697031504225">"Cererea de deblocare a reţelei a eşuat."</string>
+    <string name="unlock_failed" msgid="6490531697031504225">"Cererea de deblocare a reţelei a eșuat."</string>
     <string name="unlock_success" msgid="6770085622238180152">"Reţeaua a fost deblocată."</string>
     <string name="mobile_network_settings_not_available" msgid="3831911315358856062">"Setările pentru rețeaua mobilă nu sunt disponibile pentru acest utilizator"</string>
     <string name="labelGSMMore" msgid="5930842194056092106">"Setările apelului GSM"</string>
@@ -89,7 +89,7 @@
     <string name="sum_hide_caller_id" msgid="1071407020290873782">"Număr ascuns în apelurile de ieşire"</string>
     <string name="sum_show_caller_id" msgid="6768534125447290401">"Numărul afişat în apelurile de ieşire"</string>
     <string name="sum_default_caller_id" msgid="1954518825510901365">"Utilizaţi setările prestabilite ale operatorului, pentru a vă afişa numărul în apelurile de ieşire"</string>
-    <string name="labelCW" msgid="6120513814915920200">"Apel în aşteptare"</string>
+    <string name="labelCW" msgid="6120513814915920200">"Apel în așteptare"</string>
     <string name="sum_cw_enabled" msgid="8083061901633671397">"Anunță-mă când primesc un apel, inclusiv în timpul unei convorbiri"</string>
     <string name="sum_cw_disabled" msgid="3648693907300104575">"Anunță-mă când primesc un apel, inclusiv în timpul unei convorbiri"</string>
     <string name="call_forwarding_settings" msgid="3378927671091537173">"Setările pentru redirecţionarea de apeluri"</string>
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Operatorul dvs. nu acceptă ca redirecţionarea apelurilor să fie dezactivată atunci când telefonul nu este accesibil."</string>
     <string name="updating_title" msgid="6146755386174019046">"Setări apel"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Numai utilizatorul principal poate să modifice setările pentru apeluri."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Setări pentru apeluri (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Setări (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Eroare în setările de apel"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Se citesc setările..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"Se actualizează setările..."</string>
@@ -142,7 +142,7 @@
     <string name="vm_changed" msgid="380744030726254139">"Număr mesagerie vocală modificat."</string>
     <string name="vm_change_failed" msgid="3352934863246208918">"Nu s-a putut schimba numărul de mesagerie vocală.\nContactaţi operatorul în cazul în care această problemă persistă."</string>
     <string name="fw_change_failed" msgid="5298103228470214665">"Nu s-a putut schimba numărul de redirecţionare.\nContactaţi operatorul dvs. în cazul în care această problemă persistă."</string>
-    <string name="fw_get_in_vm_failed" msgid="8862896836093833973">"Nu s-au putut prelua și salva setările actuale ale numărului de redirecţionare.\nDoriţi să comutaţi oricum către un nou furnizor de servicii?"</string>
+    <string name="fw_get_in_vm_failed" msgid="8862896836093833973">"Nu s-au putut prelua și salva setările actuale ale numărului de redirecţionare.\nDoriți să comutaţi oricum către un nou furnizor de servicii?"</string>
     <string name="no_change" msgid="3186040086622435212">"Nicio schimbare efectuată."</string>
     <string name="sum_voicemail_choose_provider" msgid="59911196126278922">"Alegeţi serviciul de mesagerie vocală"</string>
     <string name="voicemail_default" msgid="2001233554889016880">"Operatorul dvs."</string>
@@ -418,7 +418,7 @@
     <string name="card_title_conf_call" msgid="1162980346189744501">"Teleconferinţă"</string>
     <string name="card_title_incoming_call" msgid="7364539451234646909">"Apel primit"</string>
     <string name="card_title_call_ended" msgid="5544730338889702298">"Apel încheiat"</string>
-    <string name="card_title_on_hold" msgid="821463117892339942">"În aşteptare"</string>
+    <string name="card_title_on_hold" msgid="821463117892339942">"În așteptare"</string>
     <string name="card_title_hanging_up" msgid="3999101620995182450">"Se închide telefonul"</string>
     <string name="card_title_in_call" msgid="6346543933068225205">"În timpul apelului"</string>
     <string name="notification_voicemail_title" msgid="8933468752045550523">"Mesaj vocal nou"</string>
@@ -482,7 +482,7 @@
     <string name="network_info_message" msgid="7738596060242881930">"Mesaj de rețea"</string>
     <string name="network_error_message" msgid="3394780436230411413">"Mesaj de eroare"</string>
     <string name="ota_title_activate" msgid="8616918561356194398">"Activați-vă telefonul"</string>
-    <string name="ota_touch_activate" msgid="6553212803262586244">"Pentru a vă activa serviciul de telefonie, trebuie să efectuaţi un apel special. \n\nDupă ce apăsaţi „Activați”, ascultaţi instrucţiunile furnizate pentru a vă activa telefonul."</string>
+    <string name="ota_touch_activate" msgid="6553212803262586244">"Pentru a vă activa serviciul de telefonie, trebuie să efectuați un apel special. \n\nDupă ce apăsaţi „Activați”, ascultaţi instrucţiunile furnizate pentru a vă activa telefonul."</string>
     <string name="ota_hfa_activation_title" msgid="2234246934160473981">"Se activează..."</string>
     <string name="ota_hfa_activation_dialog_message" msgid="8092479227918463415">"Serviciul de date mobile este în curs de activare pe telefonul dvs.\n\nAcest proces poate dura până la 5 minute."</string>
     <string name="ota_skip_activation_dialog_title" msgid="2943366608272261306">"Omiteţi activarea?"</string>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Ваш оператор не позволяет отключать переадресацию вызовов, если телефон находится вне зоны доступа."</string>
     <string name="updating_title" msgid="6146755386174019046">"Настройки вызовов"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Настройки вызовов может изменить только основной пользователь."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Настройки (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Настройки (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Ошибка настройки вызовов"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Чтение настроек…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"Обновление настроек…"</string>

--- a/res/values-si-rLK/strings.xml
+++ b/res/values-si-rLK/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"ඔබගේ වාහකය ඔබගේ දුරකථනය ළඟා විය නොහැකි විට ඇමතුම් ඉදිරියට ගෙනයාම අබල කිරීමට සහාය නොදක්වයි."</string>
     <string name="updating_title" msgid="6146755386174019046">"ඇමතුම් සැකසීම්"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"ඇමතුම් සැකසීම් වෙනස් කළ හැක්කේ ප්‍රධාන පරිශීලකයකු විසින් පමණි."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"ඇමතුම් සැකසීම් (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"සැකසීම් (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"ඇමතුම් සැකසුම් දෝෂය"</string>
     <string name="reading_settings" msgid="1920291699287055284">"සැකසුම් කියවමින්…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"සැකසුම් යාවත් කාලින කරමින්…"</string>

--- a/res/values-sk/strings.xml
+++ b/res/values-sk/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Váš operátor neumožňuje zakázanie presmerovaní, keď je telefón nedostupný."</string>
     <string name="updating_title" msgid="6146755386174019046">"Nastavenia hovorov"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Nastavenia hovorov môže zmeniť iba hlavný používateľ."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Nastavenia hovorov (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Nastavenia (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Chyba nastavení hovorov"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Nastavenia sa načítajú…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"Prebieha aktualizácia nastavení..."</string>

--- a/res/values-sl/strings.xml
+++ b/res/values-sl/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Vaš operater ne podpira izklopa preusmeritve klicev, kadar je telefon nedosegljiv."</string>
     <string name="updating_title" msgid="6146755386174019046">"Nastavitve klicev"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Nastavitve klicanja lahko spremeni samo primarni uporabnik."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Nastavitve klicanja (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Nastavitve (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Napaka nastavitev klicev"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Branje nastavitev …"</string>
     <string name="updating_settings" msgid="8171225533884883252">"Posodabljanje nastavitev …"</string>

--- a/res/values-sq-rAL/strings.xml
+++ b/res/values-sq-rAL/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Operatori yt nuk mbështet çaktivizimin e transferimit të telefonatës kur telefoni është i paarritshëm."</string>
     <string name="updating_title" msgid="6146755386174019046">"Cilësimet e telefonatës"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Cilësimet e telefonatës mund të ndryshohen vetëm nga përdoruesi kryesor."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Cilësimet e telefonatës (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Cilësimet (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Gabim në cilësimet e telefonatës"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Po lexon cilësimet…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"Po përditëson cilësimet…"</string>

--- a/res/values-sr/strings.xml
+++ b/res/values-sr/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Мобилни оператер не подржава онемогућавање преусмеравања позива када је телефон недоступан."</string>
     <string name="updating_title" msgid="6146755386174019046">"Подешавања позива"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Само примарни корисник може да мења подешавања позива."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Подешавања позива (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Подешавања (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Грешка у подешавањима позива"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Подешавања се учитавају…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"Ажурирање подешавања…"</string>

--- a/res/values-sv/strings.xml
+++ b/res/values-sv/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Operatören stöder inte inaktivering av vidarebefordran av samtal när det inte går att nå telefonen."</string>
     <string name="updating_title" msgid="6146755386174019046">"Samtalsinställningar"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Det är bara den primära användaren som kan ändra samtalsinställningar."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Samtalsinställningar (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Inställningar (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Felaktiga samtalsinställningar"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Läser inställningar…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"Uppdaterar inställningar…"</string>

--- a/res/values-sw/strings.xml
+++ b/res/values-sw/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Mtoa huduma wako haauni ulemezaji wa kusambaza simu wakati simu yako haifikiwi."</string>
     <string name="updating_title" msgid="6146755386174019046">"Mipangilio ya simu"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Mipangilio ya simu inaweza kubadilishwa na mtumiaji wa msingi pekee."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Mipangilio ya simu (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Mipangilio (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Hitlafu ya mipangilio ya kupiga simu"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Inasoma mipangilio…."</string>
     <string name="updating_settings" msgid="8171225533884883252">"Inaboresha mipangilio…"</string>

--- a/res/values-ta-rIN/strings.xml
+++ b/res/values-ta-rIN/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"மொபைல் தொடர்புகொள்ள முடியாத இடத்தில் இருக்கும்போது, அழைப்பு பகிர்தலை முடக்குவதை ஆபரேட்டர் ஆதரிக்கவில்லை."</string>
     <string name="updating_title" msgid="6146755386174019046">"அழைப்பு அமைப்பு"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"முதன்மை பயனர் மட்டுமே அழைப்பிற்கான அமைப்புகளை மாற்ற முடியும்."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"அழைப்பு அமைப்புகள் (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"அமைப்புகள் (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"அழைப்பு அமைப்புகளில் பிழை"</string>
     <string name="reading_settings" msgid="1920291699287055284">"அமைப்புகளைப் படிக்கிறது…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"அமைப்புகளைப் புதுப்பிக்கிறது…"</string>

--- a/res/values-te-rIN/strings.xml
+++ b/res/values-te-rIN/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"మీ ఫోన్‌ను చేరుకోవడం సాధ్యపడనప్పుడు కాల్ ఫార్వర్డింగ్‌ను నిలిపివేయడానికి మీ క్యారియర్ మద్దతు ఇవ్వదు."</string>
     <string name="updating_title" msgid="6146755386174019046">"కాల్ సెట్టింగ్‌లు"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"కాల్ సెట్టింగ్‌లను ప్రాథమిక వినియోగదారు మాత్రమే మార్చగలరు."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"కాల్ సెట్టింగ్‌లు (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"సెట్టింగ్‌లు (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"కాల్ సెట్టింగ్‌ల లోపం"</string>
     <string name="reading_settings" msgid="1920291699287055284">"సెట్టింగ్‌లను చదువుతోంది…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"సెట్టింగ్‌లను నవీకరిస్తోంది…"</string>

--- a/res/values-th/strings.xml
+++ b/res/values-th/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"ผู้ให้บริการของคุณไม่สนับสนุนการปิดใช้งานการโอนสายเมื่อติดต่อไม่ได้"</string>
     <string name="updating_title" msgid="6146755386174019046">"การตั้งค่าการโทร"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"มีเพียงผู้ใช้หลักเท่านั้นที่สามารถเปลี่ยนการตั้งค่าการโทรได้"</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"การตั้งค่าการโทร (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"การตั้งค่า (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"ข้อผิดพลาดในการตั้งค่าการโทร"</string>
     <string name="reading_settings" msgid="1920291699287055284">"กำลังประมวลการตั้งค่า…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"กำลังอัปเดตการตั้งค่า..."</string>

--- a/res/values-tl/strings.xml
+++ b/res/values-tl/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Hindi sinusuportahan ng iyong carrier ang hindi pagpapagana ng pagpasa ng tawag kapag hindi maabot ang iyong telepono."</string>
     <string name="updating_title" msgid="6146755386174019046">"Mga setting ng tawag"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Ang pangunahing user lang ang makakapagbago ng mga setting ng tawag."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Mga setting ng tawag (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Mga Setting (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Error sa mga setting ng tawag"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Binabasa ang mga setting…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"Ina-update ang mga setting…"</string>

--- a/res/values-tr/strings.xml
+++ b/res/values-tr/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Operatörünüz, telefonunuza ulaşılamadığında çağrı yönlendirmenin devre dışı bırakılmasını desteklemiyor."</string>
     <string name="updating_title" msgid="6146755386174019046">"Çağrı ayarları"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Çağrı ayarları sadece birincil kullanıcı tarafından değiştirilebilir."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Çağrı ayarları (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Ayarlar (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Çağrı ayarları hatası"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Ayarlar okunuyor..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"Ayarlar güncelleniyor..."</string>

--- a/res/values-uk/strings.xml
+++ b/res/values-uk/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Ваш оператор не підтримує вимкнення переадресації викликів, коли телефон недосяжний."</string>
     <string name="updating_title" msgid="6146755386174019046">"Налаштування викликів"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Налаштування виклику може змінити лише основний користувач."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Налаштування виклику (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Налаштування (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Помилка налаштування викликів"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Читання налаштувань…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"Оновлення налаштувань…"</string>

--- a/res/values-ur-rPK/strings.xml
+++ b/res/values-ur-rPK/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"آپ کا کیریئر آپ کا فون ناقابل رسائی ہونے پر کال آگے منتقل کرنے کو غیر فعال کرنے کا تعاون نہیں کرتا ہے۔"</string>
     <string name="updating_title" msgid="6146755386174019046">"کال کی ترتیبات"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"صرف بنیادی صارف ہی کال کی ترتیبات تبدیل کر سکتا ہے۔"</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"کال کی ترتیبات (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"ترتیبات (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"کال کی ترتیبات کی خرابی"</string>
     <string name="reading_settings" msgid="1920291699287055284">"ترتیبات کو پڑھ رہا ہے…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"ترتیبات کو اپ ڈیٹ کر رہا ہے…"</string>

--- a/res/values-uz-rUZ/strings.xml
+++ b/res/values-uz-rUZ/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Telefoningiz o‘chiq bo‘lganida qo‘ng‘iroqlarni boshqa raqamga yo‘naltirishni o‘chirish xususiyati tarmoq operatoringizda yo‘q."</string>
     <string name="updating_title" msgid="6146755386174019046">"Qo‘ng‘iroq sozlamalari"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Faqat asosiy foydalanuvchi qo‘ng‘iroq sozlamalarini o‘zgartirishi mumkin."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Qo‘ng‘iroq sozlamalari (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Sozlamalar (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Qo‘ng‘iroq sozlamalarida xato"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Sozlamalar o‘qilmoqda…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"Sozlamalar yangilanmoqda…"</string>

--- a/res/values-vi/strings.xml
+++ b/res/values-vi/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Nhà cung cấp dịch vụ của bạn không hỗ trợ vô hiệu hóa chuyển tiếp cuộc gọi khi điện thoại của bạn không thể truy cập được."</string>
     <string name="updating_title" msgid="6146755386174019046">"Cài đặt cuộc gọi"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Chỉ người dùng chính mới có thể thay đổi cài đặt cuộc gọi."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Cài đặt cuộc gọi (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Cài đặt (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Lỗi cài đặt cuộc gọi"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Đang đọc cài đặt…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"Đang cập nhật cài đặt..."</string>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"您的运营商不支持在手机无法接通时停用来电转接功能。"</string>
     <string name="updating_title" msgid="6146755386174019046">"通话设置"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"只有主用户才能更改通话设置。"</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"通话设置 (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"设置（<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>）"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"通话设置出错"</string>
     <string name="reading_settings" msgid="1920291699287055284">"正在读取设置..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"正在更新设置..."</string>

--- a/res/values-zh-rHK/strings.xml
+++ b/res/values-zh-rHK/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"您的流動網絡供應商不支援在手機無法接通時停用轉接功能。"</string>
     <string name="updating_title" msgid="6146755386174019046">"通話設定"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"只有主要使用者可以變更通話設定。"</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"通話設定 (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"設定 (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"通話設定錯誤"</string>
     <string name="reading_settings" msgid="1920291699287055284">"正在讀取設定..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"正在更新設定..."</string>

--- a/res/values-zh-rTW/strings.xml
+++ b/res/values-zh-rTW/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"您的行動通訊業者不支援手機無收訊時停用轉接功能。"</string>
     <string name="updating_title" msgid="6146755386174019046">"通話設定"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"只有主要使用者可以變更通話設定。"</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"通話設定 (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"設定 (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"通話設定錯誤"</string>
     <string name="reading_settings" msgid="1920291699287055284">"正在讀取設定…"</string>
     <string name="updating_settings" msgid="8171225533884883252">"更新設定中…"</string>

--- a/res/values-zu/strings.xml
+++ b/res/values-zu/strings.xml
@@ -118,7 +118,7 @@
     <string name="disable_cfnrc_forbidden" msgid="5646361343094064333">"Isiphathi sakho asisekeli ukuvimbela ukudlulisela ucingo lapho ifoni yakho ingafinyeleleki."</string>
     <string name="updating_title" msgid="6146755386174019046">"Izilungiselelo zekholi"</string>
     <string name="call_settings_primary_user_only" msgid="5679923943740900965">"Izilungiselelo zekholi zingaguqulwa kuphela ngumsebenzisi oyinhloko."</string>
-    <string name="call_settings_with_label" msgid="89359812614544532">"Izilungiselelo zekholi (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
+    <string name="call_settings_with_label" msgid="3401177261468593519">"Izilungiselelo (<xliff:g id="SUBSCRIPTIONLABEL">%s</xliff:g>)"</string>
     <string name="error_updating_title" msgid="7970259216988931777">"Iphutha lokulungiselela ikholi"</string>
     <string name="reading_settings" msgid="1920291699287055284">"Ifunda izilungiselelo..."</string>
     <string name="updating_settings" msgid="8171225533884883252">"Ibuyekeza izilungiselelo..."</string>

--- a/res/values/cm_arrays.xml
+++ b/res/values/cm_arrays.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2014-2015 The CyanogenMod Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string-array name="preferred_network_mode_choices_cm" translatable="false">
+        <item>@string/preferred_network_mode_td_scdma_lte_gsm_wcdma_cdma_evdo_choice </item>
+        <item>@string/preferred_network_mode_td_scdma_gsm_wcdma_cdma_evdo_choice</item>
+        <item>@string/preferred_network_mode_td_scdma_gsm_wcdma_lte_choice</item>
+        <item>@string/preferred_network_mode_td_scdma_wcdma_lte_choice</item>
+        <item>@string/preferred_network_mode_td_scdma_gsm_wcdma_choice</item>
+        <item>@string/preferred_network_mode_td_scdma_gsm_lte_choice</item>
+        <item>@string/preferred_network_mode_td_scdma_gsm_choice</item>
+        <item>@string/preferred_network_mode_td_scdma_lte_choice</item>
+        <item>@string/preferred_network_mode_td_scdma_wcdma_choice</item>
+        <item>@string/preferred_network_mode_td_scdma_only_choice</item>
+        <item>@string/preferred_network_mode_lte_wcdma_choice</item>
+        <item>@string/preferred_network_mode_lte_choice</item>
+        <item>@string/preferred_network_mode_global_choice</item>
+        <item>@string/preferred_network_mode_gsm_wcdma_lte_choice</item>
+        <item>@string/preferred_network_mode_cdma_lte_evdo_choice</item>
+        <item>@string/preferred_network_mode_cdma_evdo_gsm_wcdma_choice</item>
+        <item>@string/preferred_network_mode_evdo_only_choice</item>
+        <item>@string/preferred_network_mode_cdma_wo_evdo_choice</item>
+        <item>@string/preferred_network_mode_cdma_evdo_auto_choice</item>
+        <item>@string/preferred_network_mode_gsm_wcdma_auto_choice</item>
+        <item>@string/preferred_network_mode_wcdma_only_choice</item>
+        <item>@string/preferred_network_mode_gsm_only_choice</item>
+        <item>@string/preferred_network_mode_gsm_wcdma_preferred_choice</item>
+    </string-array>
+</resources>

--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+     Copyright (C) 2013-2014 The CyanogenMod Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="preferred_network_mode_td_scdma_lte_gsm_wcdma_cdma_evdo_choice">TD-SCDMA/LTE/GSM/WCDMA/CDMA/EVDO</string>
+    <string name="preferred_network_mode_td_scdma_gsm_wcdma_cdma_evdo_choice">TD-SCDMA/GSM/WCDMA/CDMA/EVDO</string>
+    <string name="preferred_network_mode_td_scdma_gsm_wcdma_lte_choice">TD-SCDMA/GSM/WCDMA/LTE</string>
+    <string name="preferred_network_mode_td_scdma_wcdma_lte_choice">TD-SCDMA/WCDMA/LTE</string>
+    <string name="preferred_network_mode_td_scdma_gsm_wcdma_choice">TD-SCDMA/GSM/WCDMA</string>
+    <string name="preferred_network_mode_td_scdma_gsm_lte_choice">TD-SCDMA/GSM/LTE</string>
+    <string name="preferred_network_mode_td_scdma_gsm_choice">TD-SCDMA/GSM</string>
+    <string name="preferred_network_mode_td_scdma_lte_choice">TD-SCDMA/LTE</string>
+    <string name="preferred_network_mode_td_scdma_wcdma_choice">TD-SCDMA/WCDMA</string>
+    <string name="preferred_network_mode_td_scdma_only_choice">TD-SCDMA only</string>
+    <string name="preferred_network_mode_lte_wcdma_choice">LTE / WCDMA</string>
+    <string name="preferred_network_mode_lte_choice">LTE</string>
+    <string name="preferred_network_mode_global_choice">Global</string>
+    <string name="preferred_network_mode_gsm_wcdma_lte_choice">GSM/WCDMA/LTE</string>
+    <string name="preferred_network_mode_cdma_lte_evdo_choice">CDMA  LTE/EvDo</string>
+    <string name="preferred_network_mode_cdma_evdo_gsm_wcdma_choice">CDMA/EvDo/GSM/WCDMA</string>
+    <string name="preferred_network_mode_evdo_only_choice">EvDo only</string>
+    <string name="preferred_network_mode_cdma_wo_evdo_choice">CDMA w/o EvDo</string>
+    <string name="preferred_network_mode_cdma_evdo_auto_choice">CDMA/EvDo auto</string>
+    <string name="preferred_network_mode_gsm_wcdma_auto_choice">GSM/WCDMA auto</string>
+    <string name="preferred_network_mode_wcdma_only_choice">WCDMA only</string>
+    <string name="preferred_network_mode_gsm_only_choice">GSM only</string>
+    <string name="preferred_network_mode_gsm_wcdma_preferred_choice">GSM/WCDMA preferred</string>
+
+</resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -274,7 +274,7 @@
     <!-- Toast in Call settings when asked to launch settings for a secondary user -->
     <string name="call_settings_primary_user_only">Call settings can only be changed by the primary user.</string>
     <!-- Title of the "Call settings" settings screen, with a text label identifying which SIM the settings are for. -->
-    <string name="call_settings_with_label">Call settings (<xliff:g id="subscriptionlabel" example="Verizon">%s</xliff:g>)</string>
+    <string name="call_settings_with_label">Settings (<xliff:g id="subscriptionlabel" example="Mock Carrier">%s</xliff:g>)</string>
     <!-- Title of the alert dialog displayed if an error occurs while updating Call settings -->
     <string name="error_updating_title">Call settings error</string>
     <!-- Toast in Call settings dialog while settings are being read -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -20,7 +20,7 @@
          and other settings UIs.  This is the version of the label for
          tablet devices, where the phone app handles mobile data but not
          actual phone calls. -->
-    <string name="phoneAppLabel" product="tablet">Cellular Data</string>
+    <string name="phoneAppLabel" product="tablet">Mobile Data</string>
 
     <!-- Official label of the phone app, as seen in "Manage Applications"
          and other settings UIs. -->
@@ -115,7 +115,7 @@
     <!-- settings strings -->
 
     <!-- Error message for users that aren't allowed to modify Mobile Network settings [CHAR LIMIT=none] -->
-    <string name="mobile_network_settings_not_available">Cellular network settings are not available for this user</string>
+    <string name="mobile_network_settings_not_available">Mobile network settings are not available for this user</string>
     <!-- GSM Call settings screen, setting option name. [CHAR LIMIT=40] -->
     <string name="labelGSMMore">GSM call settings</string>
     <!-- GSM Call settings screen, setting option name with label indicating the SIM the settings
@@ -344,7 +344,7 @@
 
     <!-- networks setting strings --><skip/>
     <!-- Mobile network settings screen title -->
-    <string name="mobile_networks">Cellular network settings</string>
+    <string name="mobile_networks">Mobile network settings</string>
     <!-- Available networks screen title/heading -->
     <string name="label_available">Available networks</string>
     <!-- Mobile network settings screen, toast when searching for available networks -->
@@ -1104,9 +1104,9 @@
          This string is currently unused (see comments in InCallScreen.java.) -->
     <string name="incall_error_emergency_only">Not registered on network.</string>
     <!-- In-call screen: call failure message displayed in an error dialog -->
-    <string name="incall_error_out_of_service">Cellular network not available.</string>
+    <string name="incall_error_out_of_service">Mobile network not available.</string>
     <!-- In-call screen: call failure message displayed in an error dialog -->
-    <string name="incall_error_out_of_service_wfc">Cellular network is not available. Connect to a wireless network to make a call.</string>
+    <string name="incall_error_out_of_service_wfc">Mobile network is not available. Connect to a wireless network to make a call.</string>
     <!-- In-call screen: call failure message displayed in an error dialog -->
     <string name="incall_error_no_phone_number_supplied">To place a call, enter a valid number.</string>
     <!-- In-call screen: call failure message displayed in an error dialog -->

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -186,11 +186,7 @@
         <item name="android:textColor">?android:attr/textColorPrimaryInverseDisableOnly</item>
     </style>
 
-    <style name="NetworkOperatorsSettingsTheme" parent="@android:style/Theme.Material.Light">
-        <item name="android:actionBarTheme">@android:style/ThemeOverlay.Material.Dark.ActionBar</item>
-        <item name="android:colorPrimary">@color/network_operators_color_primary</item>
-        <item name="android:colorPrimaryDark">@color/network_operators_color_primary_dark</item>
-    </style>
+    <style name="NetworkOperatorsSettingsTheme" parent="@style/Theme.Material.Settings"/>
 
     <style name="Empty" parent="@android:style/Theme.Material.Light">
         <item name="android:windowIsTranslucent">true</item>

--- a/res/xml/carrier_select.xml
+++ b/res/xml/carrier_select.xml
@@ -13,7 +13,9 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+        android:key="list_networks_key"
+        android:title="@string/label_available">
     <Preference
         android:key="button_auto_select_key"
         android:title="@string/select_automatically"

--- a/res/xml/carrier_select.xml
+++ b/res/xml/carrier_select.xml
@@ -13,16 +13,9 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-        android:key="list_networks_key" 
-        android:title="@string/label_available">
-    <Preference 
-        android:key="button_srch_netwrks_key" 
-        android:title="@string/search_networks"
-        android:summary="@string/sum_search_networks"
-        android:persistent="false"/>
-    <Preference 
-        android:key="button_auto_select_key" 
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <Preference
+        android:key="button_auto_select_key"
         android:title="@string/select_automatically"
         android:summary="@string/sum_select_automatically"
         android:persistent="false"/>

--- a/res/xml/network_setting.xml
+++ b/res/xml/network_setting.xml
@@ -32,7 +32,7 @@
         android:key="preferred_network_mode_key"
         android:title="@string/preferred_network_mode_title"
         android:summary="@string/preferred_network_mode_summary"
-        android:entries="@array/preferred_network_mode_choices"
+        android:entries="@array/preferred_network_mode_choices_cm"
         android:entryValues="@array/preferred_network_mode_values"
         android:dialogTitle="@string/preferred_network_mode_dialogtitle" />
 

--- a/sip/src/com/android/services/telephony/sip/SipBroadcastReceiver.java
+++ b/sip/src/com/android/services/telephony/sip/SipBroadcastReceiver.java
@@ -58,7 +58,13 @@ public class SipBroadcastReceiver extends BroadcastReceiver {
 
     private void takeCall(Context context, Intent intent) {
         if (VERBOSE) log("takeCall, intent: " + intent);
-        PhoneAccountHandle accountHandle = intent.getParcelableExtra(SipUtil.EXTRA_PHONE_ACCOUNT);
+        PhoneAccountHandle accountHandle = null;
+        try {
+            accountHandle = intent.getParcelableExtra(SipUtil.EXTRA_PHONE_ACCOUNT);
+        } catch (ClassCastException e) {
+            log("takeCall, Bad account handle detected. Bailing!");
+            return;
+        }
         if (accountHandle != null) {
             Bundle extras = new Bundle();
             extras.putParcelable(SipUtil.EXTRA_INCOMING_CALL_INTENT, intent);

--- a/sip/src/com/android/services/telephony/sip/SipConnection.java
+++ b/sip/src/com/android/services/telephony/sip/SipConnection.java
@@ -134,7 +134,14 @@ final class SipConnection extends Connection {
         try {
             if (getPhone() != null && getState() == STATE_ACTIVE
                     && getPhone().getRingingCall().getState() != Call.State.WAITING) {
-                getPhone().switchHoldingAndActive();
+                // Double check with the internal state since a discrepancy in states could mean
+                // that the transactions is already in progress from a previous request.
+                if (mOriginalConnection != null &&
+                        mOriginalConnection.getState() == Call.State.ACTIVE) {
+                    getPhone().switchHoldingAndActive();
+                } else {
+                    log("skipping switch from onHold due to internal state:");
+                }
             }
         } catch (CallStateException e) {
             log("onHold, exception: " + e);
@@ -145,8 +152,16 @@ final class SipConnection extends Connection {
     public void onUnhold() {
         if (VERBOSE) log("onUnhold");
         try {
-            if (getPhone() != null && getState() == STATE_HOLDING) {
-                getPhone().switchHoldingAndActive();
+            if (getPhone() != null && getState() == STATE_HOLDING &&
+                    getPhone().getForegroundCall().getState() != Call.State.DIALING) {
+                // Double check with the internal state since a discrepancy in states could mean
+                // that the transaction is already in progress from a previous request.
+                if (mOriginalConnection != null &&
+                        mOriginalConnection.getState() == Call.State.HOLDING) {
+                    getPhone().switchHoldingAndActive();
+                } else {
+                    log("skipping switch from onUnHold due to internal state.");
+                }
             }
         } catch (CallStateException e) {
             log("onUnhold, exception: " + e);

--- a/src/com/android/phone/CdmaSystemSelectListPreference.java
+++ b/src/com/android/phone/CdmaSystemSelectListPreference.java
@@ -72,21 +72,15 @@ public class CdmaSystemSelectListPreference extends ListPreference {
                     Settings.Global.getInt(mPhone.getContext().getContentResolver(),
                     Settings.Global.CDMA_ROAMING_MODE, Phone.CDMA_RM_HOME);
             if (buttonCdmaRoamingMode != settingsCdmaRoamingMode) {
-                int statusCdmaRoamingMode;
-                switch(buttonCdmaRoamingMode) {
-                    case Phone.CDMA_RM_ANY:
-                        statusCdmaRoamingMode = Phone.CDMA_RM_ANY;
-                        break;
-                    case Phone.CDMA_RM_HOME:
-                    default:
-                        statusCdmaRoamingMode = Phone.CDMA_RM_HOME;
-                }
                 //Set the Settings.Secure network mode
                 Settings.Global.putInt(mPhone.getContext().getContentResolver(),
                         Settings.Global.CDMA_ROAMING_MODE,
                         buttonCdmaRoamingMode );
                 //Set the roaming preference mode
-                mPhone.setCdmaRoamingPreference(statusCdmaRoamingMode, mHandler
+                // Note: buttonCdmaRoamingMode was previously vetted against the
+                // device-specific cdma_system_select_values list, and so doesn't need to
+                // be coerced again here.
+                mPhone.setCdmaRoamingPreference(buttonCdmaRoamingMode, mHandler
                         .obtainMessage(MyHandler.MESSAGE_SET_ROAMING_PREFERENCE));
             }
         } else {
@@ -121,9 +115,16 @@ public class CdmaSystemSelectListPreference extends ListPreference {
                 int settingsRoamingMode = Settings.Global.getInt(
                         mPhone.getContext().getContentResolver(),
                         Settings.Global.CDMA_ROAMING_MODE, Phone.CDMA_RM_HOME);
-                //check that statusCdmaRoamingMode is from an accepted value
-                if (statusCdmaRoamingMode == Phone.CDMA_RM_HOME ||
-                        statusCdmaRoamingMode == Phone.CDMA_RM_ANY ) {
+
+                // Ensure that statusCdmaRoamingMode is a value that appears in the
+                // cdma_system_select_values list.  Note that this check used to be
+                // hardcoded against Phone.CDMA_RM_HOME and Phone.CDMA_RM_ANY, however,
+                // some devices (e.g., epicmtd) have radios that support additional roaming
+                // options which should be specified in an overlay .xml file.  Should the
+                // radio report an option that's _not_ present in that list, fall back to
+                // the default roaming mode so that the user doesn't operate in a mode he
+                // can't verify.
+                if (findIndexOfValue(Integer.toString(statusCdmaRoamingMode)) != -1) {
                     //check changes in statusCdmaRoamingMode and updates settingsRoamingMode
                     if (statusCdmaRoamingMode != settingsRoamingMode) {
                         settingsRoamingMode = statusCdmaRoamingMode;

--- a/src/com/android/phone/MobileNetworkSettings.java
+++ b/src/com/android/phone/MobileNetworkSettings.java
@@ -633,6 +633,10 @@ public class MobileNetworkSettings extends PreferenceActivity
             } else {
                 throw new IllegalStateException("Unexpected phone type: " + phoneType);
             }
+            // Since pref is being hidden from user, set network mode to default
+            // in case it is currently something else. That is possible if user
+            // changed the setting while roaming and is now back to home network.
+            settingsNetworkMode = preferredNetworkMode;
         } else if (carrierConfig.getBoolean(CarrierConfigManager.KEY_WORLD_PHONE_BOOL) == true) {
             prefSet.removePreference(mButtonEnabledNetworks);
             // set the listener for the mButtonPreferredNetworkMode list preference so we can issue

--- a/src/com/android/phone/TimeConsumingPreferenceActivity.java
+++ b/src/com/android/phone/TimeConsumingPreferenceActivity.java
@@ -117,7 +117,7 @@ public class TimeConsumingPreferenceActivity extends PreferenceActivity
                 default:
                     msgId = R.string.exception_error;
                     // The error is not recoverable on dialog exit.
-                    builder.setPositiveButton(R.string.close_dialog, mDismiss);
+                    builder.setPositiveButton(R.string.close_dialog, mDismissAndFinish);
                     break;
             }
 

--- a/src/com/android/services/telephony/TelecomAccountRegistry.java
+++ b/src/com/android/services/telephony/TelecomAccountRegistry.java
@@ -474,6 +474,10 @@ final class TelecomAccountRegistry {
                     Log.w(this, "Failed to get status for, slotId: "+ slotId +" Exception: " + ex);
                 }
 
+                if (provisionStatus == INVALID_STATE) {
+                    provisionStatus = PROVISIONED;
+                }
+
                 Log.d(this, "Phone with subscription id: " + subscriptionId +
                                 " slotId: " + slotId + " provisionStatus: " + provisionStatus);
             }

--- a/src/com/android/services/telephony/TelephonyConnection.java
+++ b/src/com/android/services/telephony/TelephonyConnection.java
@@ -890,11 +890,20 @@ abstract class TelephonyConnection extends Connection {
         setWifi(mOriginalConnection.isWifi());
         setVideoProvider(mOriginalConnection.getVideoProvider());
         setAudioQuality(mOriginalConnection.getAudioQuality());
+        updateExtras(mOriginalConnection.getConnectionExtras());
 
         if (isImsConnection()) {
             mWasImsConnection = true;
         }
         mIsMultiParty = mOriginalConnection.isMultiparty();
+
+        // updateState can set mOriginalConnection to null if its state is DISCONNECTED, so this
+        // should be executed *after* the above setters have run.
+        updateState();
+        if (mOriginalConnection == null) {
+            Log.w(this, "original Connection was nulled out as part of setOriginalConnection. " +
+                    originalConnection);
+        }
 
         fireOnOriginalConnectionConfigured();
     }


### PR DESCRIPTION
If the provisioning state is invalid, the framework is most likely
absent. Consider the card as provisioned to pass all relevant checks.

Change-Id: I71e170aa9bf872057cb0e75257cc712d500aa43b